### PR TITLE
Allow not overwriting Lua path/cpath

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -229,7 +229,8 @@
                             "path": {
                                 "type": [
                                     "string",
-                                    "array"
+                                    "array",
+                                    "null"
                                 ],
                                 "markdownDescription": "Search path for Lua programs",
                                 "default": "${workspaceFolder}/?.lua"
@@ -237,7 +238,8 @@
                             "cpath": {
                                 "type": [
                                     "string",
-                                    "array"
+                                    "array",
+                                    "null"
                                 ],
                                 "markdownDescription": "Search path for native libraries",
                                 "default": "${workspaceFolder}/?.dll"

--- a/extension/script/backend/worker.lua
+++ b/extension/script/backend/worker.lua
@@ -454,7 +454,7 @@ end
 
 function CMD.setSearchPath(pkg)
     local function set_search_path(name)
-        if not pkg[name] then
+        if not pkg[name] or pkg[name] == json.null then
             return
         end
         local value = pkg[name]


### PR DESCRIPTION
Use case:
I wanted to use the system Lua install, so I added in launch.json:
`"luaexe": "/usr/bin/lua5.3"`

This was not enough, as the default path and cpath was overwritten. Hence this PR which enables not overwriting Lua package.path and .cpath with this in launch.json:
`"path": null, "cpath": null`