### PR TITLE
lazy load launcher

### DIFF
--- a/extension/script/frontend/process_inject.lua
+++ b/extension/script/frontend/process_inject.lua
@@ -51,8 +51,8 @@ function _M.gdb_inject(pid, entry, injectdll, gdb_path)
 
     local launcher = {
         "-ex",
-        -- 6 = RTDL_NOW|RTDL_LOCAL
-        ('print  (void*)dlopen("%s", 6)'):format(injectdll),
+        -- 5 = RTDL_LAZY|RTDL_LOCAL
+        ('print  (void*)dlopen("%s", 5)'):format(injectdll),
         "-ex",
         ('call ((void(*)())&%s)()'):format(entry),
         "-ex",
@@ -93,8 +93,8 @@ function _M.lldb_inject(pid, entry, injectdll, lldb_path)
 
     local launcher = {
         "-o",
-        -- 6 = RTDL_NOW|RTDL_LOCAL
-        ('expression (void*)dlopen("%s", 6)'):format(injectdll),
+        -- 5 = RTDL_LAZY|RTDL_LOCAL
+        ('expression (void*)dlopen("%s", 5)'):format(injectdll),
         "-o",
         ('expression ((void(*)())&%s)()'):format(entry),
         "-o",

--- a/src/process_inject/macos/shellcode.cpp
+++ b/src/process_inject/macos/shellcode.cpp
@@ -37,7 +37,7 @@ static void* rmain(void* ptr) {
     // load lib
     {
         auto _dlopen = (decltype(&dlopen))arg.get_func("dlopen");
-        handler      = _dlopen((const char*)arg.name, RTLD_NOW | RTLD_LOCAL);
+        handler      = _dlopen((const char*)arg.name, RTLD_LAZY | RTLD_LOCAL);
     }
     if (!handler) {
         auto ec       = (const char*)_dlerror();


### PR DESCRIPTION
延迟绑定launcher,为了之后可以把frida模块改成动态库,让luadebug中可以使用,而不必使用两份frida代码在一个进程内