### PR TITLE
macos: fix  copy error

### DIFF
--- a/compile/copy.lua
+++ b/compile/copy.lua
@@ -56,6 +56,10 @@ local function copy_directory(from, to, filter)
                 if not crtdll(filename:string():lower()) then
                     print('copy', fromfile, to / filename)
                 end
+                if OS == "macos" then
+                    -- must remove first, it will cause a code signature error
+                    fs.remove(to / filename)
+                end
                 fs.copy_file(fromfile, to / filename, fs.copy_options.overwrite_existing)
             end
         end


### PR DESCRIPTION
https://developer.apple.com/documentation/security/updating_mac_software?language=objc

copy_file api使用的是文件覆盖,可能导致macos内核未刷新该文件的签名,导致无法运行,这个需要macos重启才能刷新.

我相信你也遇见过这个问题,我之前一直都没找到原因,之前都是手动签名一遍库.