### PR TITLE
Fix error statement when wget command is missing

### DIFF
--- a/compile/download_deps.lua
+++ b/compile/download_deps.lua
@@ -58,7 +58,7 @@ local function download(url, output, dir)
     for _, cmd in ipairs(cmds) do
         local p, err = sp.spawn(cmd)
         if not p then
-            error(cmd[1], err)
+            error(cmd[1] .. ":" .. err)
         end
         p:wait()
     end


### PR DESCRIPTION
`compile/download_deps.lua` assumes wget is in the current `PATH`.

However, should this CLI tool be missing, it will not be able to output an error:

```
download_deps.lua:61: bad argument #2 to 'error' (number expected, got string)
```

Fixing the error message to use the correct form of the built-in [error()](https://www.lua.org/manual/5.4/manual.html#pdf-error) function by concatenating the command path and the error string `err`.

Output becomes the following which now indicates the root cause:

```
compile/download_deps.lua:61: wget:subprocess::spawn: (generic:2)No such file or directory
```