### PR TITLE
sourceCoding missing MacOS/Linux

### DIFF
--- a/compile/common/package_json.lua
+++ b/compile/common/package_json.lua
@@ -188,6 +188,15 @@ attributes.common = {
         markdownDescription = "Path format",
         type = "string",
     },
+    sourceCoding = {
+        default = "utf8",
+        enum = {
+            "utf8",
+            "ansi",
+        },
+        markdownDescription = "%lua.debug.launch.sourceCoding.description%",
+        type = "string",
+    },
     sourceFormat = {
         default = "path",
         enum = {
@@ -424,15 +433,6 @@ if OS == "win32" or OS == "darwin" then
 end
 
 if OS == "win32" then
-    attributes.common.sourceCoding = {
-        default = "utf8",
-        enum = {
-            "utf8",
-            "ansi",
-        },
-        markdownDescription = "%lua.debug.launch.sourceCoding.description%",
-        type = "string",
-    }
     attributes.common.useWSL = {
         default = true,
         description = "Use Windows Subsystem for Linux.",


### PR DESCRIPTION
Hi!

I saw a tiny issue and fixed it.

Specifically VSCode shows an error "Property `sourceCoding` is not allowed." on platforms other than Windows (screenshot is Mac).

<img width="727" alt="image" src="https://github.com/actboy168/lua-debug/assets/145113/e04f93ac-006f-495c-a052-8805227bc590">

I was able to get an extension development environment setup, make the change and validate my fix worked.

Thanks for making this extension!