### PR TITLE
show error in logs when sourceMaps are set incorrectly

### DIFF
--- a/extension/script/backend/worker/source.lua
+++ b/extension/script/backend/worker/source.lua
@@ -28,7 +28,10 @@ ev.on('initializing', function(config)
         end
     end
     if config.sourceMaps then
-        for _, pattern in ipairs(config.sourceMaps) do
+        for i, pattern in ipairs(config.sourceMaps) do
+            if pattern[1] == nil or pattern[2] == nil then
+                error(("Invalid source map entry. Check sourceMaps property in launch.json, entry #%d"):format(i - 1))
+            end
             local sm = {}
             sm[1] = ('^%s$'):format(fs.source_native(fs.source_normalize(pattern[1])):gsub('[%^%$%(%)%%%.%[%]%+%-%?]', '%%%0'))
             if sm[1]:find '%*' then

--- a/extension/script/backend/worker/variables.lua
+++ b/extension/script/backend/worker/variables.lua
@@ -139,10 +139,7 @@ end
 
 function special_has.Return(frameId)
     rdebug.getinfo(frameId, "r", info)
-    return info.ftransfer ~= nil and
-      info.ntransfer ~= nil and
-      info.ftransfer > 0 and
-      info.ntransfer > 0
+    return info.ftransfer > 0 and info.ntransfer > 0
 end
 
 function special_has.Global(frameId)

--- a/extension/script/backend/worker/variables.lua
+++ b/extension/script/backend/worker/variables.lua
@@ -139,7 +139,10 @@ end
 
 function special_has.Return(frameId)
     rdebug.getinfo(frameId, "r", info)
-    return info.ftransfer > 0 and info.ntransfer > 0
+    return info.ftransfer ~= nil and
+      info.ntransfer ~= nil and
+      info.ftransfer > 0 and
+      info.ntransfer > 0
 end
 
 function special_has.Global(frameId)


### PR DESCRIPTION
Thank you for this project, it is a hidden gem. I have just found about it and now I can debug my Lua code!

This PR is a small fix so that variables are shown in the VSCode debugger VARIABLES window when debugging a LuaJIT target.

The following error was shown in the logs:
```
[ERROR]ERROR:...lua-debug-2.0.12-linux-x64/script/backend/worker/variables.lua:142: attempt to compare number with nil
```

` rdebug.getinfo(frameId, "r", info)` is not implemented for LuaJIT, so `ftransfer` and `ntransfer` are not populated.

With this fix I can now inspect all the variables, globals and upvalues!

