### PR TITLE
fix GCC compilation error due to _bee_lua_apicheck() sig mismatch

### DIFF
--- a/src/luadebug/luadbg/onelua.c
+++ b/src/luadebug/luadbg/onelua.c
@@ -94,7 +94,8 @@ void _bee_lua_assert(const char* message, const char* file, unsigned line) {
     abort();
 }
 
-void _bee_lua_apicheck(lua_State* L, const char* message, const char* file, unsigned line) {
+void _bee_lua_apicheck(void* l, const char* message, const char* file, unsigned line) {
+    lua_State* L = l;
     fprintf(stderr, "(%s:%d) %s\n", file, line, message);
     fflush(stderr);
     if (!lua_checkstack(L, LUA_MINSTACK)) {


### PR DESCRIPTION
`_bee_lua_apicheck` function has this signature upstream:

```cpp
_bee_lua_apicheck(void* l, const char* message, const char* file, unsigned line)
```

However, `onlelua.c` has this signature:

```cpp
_bee_lua_apicheck(lua_State* L, const char* message, const char* file, unsigned line)
```
(first parameter is of different type)

This causes compilation errors, at least in GCC 13. The PR fixes this.