### PR TITLE
fix: allow quick restart in Linux

### DIFF
--- a/extension/script/common/net.lua
+++ b/extension/script/common/net.lua
@@ -176,6 +176,15 @@ function m.listen(protocol, address, port)
             fs.remove(address)
         end
     end
+	do
+        -- set SO_REUSEADDR so we can bind again to the same address
+        -- after a quick restart:
+		local ok, err = fd:option("reuseaddr", 1)
+		if not ok then
+			fd:close()
+			return nil, err
+		end
+	end
     do
         local ok, err = fd:bind(address, port)
         if not ok then

--- a/extension/script/common/socket.lua
+++ b/extension/script/common/socket.lua
@@ -119,12 +119,12 @@ return function (param)
             session:close()
             fds[1] = session
         elseif t.mode == "listen" then
-            server:close()
-            fds[1] = server
-            if session ~= nil then
-                session:close()
-                fds[2] = session
-            end
+			fds[1] = server
+			if session ~= nil then
+				session:close()
+				fds[2] = session
+			end
+			server:close()
         end
         local function is_finish()
             for _, fd in ipairs(fds) do


### PR DESCRIPTION
On Linux, I’ve encountered an issue where terminating the host application leaves the debugger’s listening socket in the `TIME_WAIT` state. This prevents the debugger from rebinding to the same address upon restarting the application.

During active debugging sessions, frequent restarts are common after identifying issues. However, because the socket remains in `TIME_WAIT`, the debugger fails to bind again, reporting the address as already in use. This forces the user to wait for the OS to release the socket before continuing.

This PR addresses the problem by enabling the `SO_REUSEADDR` socket option, allowing the debugger to rebind to the same address immediately after a restart.