### PR TITLE
ISSUE 340: Hangs on Start - v2.2.2 - Fedora 42

### DIFF
--- a/extension/script/common/socket.lua
+++ b/extension/script/common/socket.lua
@@ -5,7 +5,7 @@ local function parseAddress(param)
     local mode, address = param:match "^([a-z]+):(.*)"
     if address:sub(1,1) == '@' then
         local fs = require "bee.filesystem"
-        address = address:gsub("%$tmp", fs.temp_directory_path():string():gsub("([/\\])$", ""))
+        address = address:gsub("%$tmp", (fs.temp_directory_path():string():gsub("([/\\])$", "")))
         return {
             protocol = 'unix',
             address = address:sub(2),


### PR DESCRIPTION
Fix for ISSUE #340:

* Fix unix socket address generation on linux systems

The string:gsub() function returns the modified string and an integer representing the number of matches replaced. Adding the parentheses selects just the modified string.