### PR TITLE
proxy forgets packages if debuggee connects

### DIFF
--- a/extension/script/common/socket.lua
+++ b/extension/script/common/socket.lua
@@ -86,7 +86,11 @@ return function (param)
         server = assert(net.listen(t.protocol, t.address, t.port))
         function server:on_accepted(new_s)
             local ok = init_session(new_s)
-            assert(ok)
+            if not ok then
+                new_s:close()
+                error "Failed to initialize session."
+                return
+            end
             if writebuf ~= '' then
                 new_s:write(writebuf)
                 writebuf = ''

--- a/extension/script/common/socket.lua
+++ b/extension/script/common/socket.lua
@@ -85,7 +85,13 @@ return function (param)
     elseif t.mode == "listen" then
         server = assert(net.listen(t.protocol, t.address, t.port))
         function server:on_accepted(new_s)
-            return init_session(new_s)
+            local ok = init_session(new_s)
+            assert(ok)
+            if writebuf ~= '' then
+                new_s:write(writebuf)
+                writebuf = ''
+            end
+            return ok
         end
     else
         return


### PR DESCRIPTION
this might fix #344

when lua-debug wait for a conencting debuggee, after the connection is accepted nothing happens. lua-debug should send queued packages in that case, as it does in the other case where lua-debug connects to the debuggee