### PR TITLE
修复 Continue 后误命中已移除断点的问题

### DIFF
--- a/extension/script/backend/worker.lua
+++ b/extension/script/backend/worker.lua
@@ -496,6 +496,7 @@ end
 
 function CMD.run()
     state = 'running'
+    hookmgr.break_closeline()
     hookmgr.step_cancel()
 end
 

--- a/extension/script/backend/worker.lua
+++ b/extension/script/backend/worker.lua
@@ -30,6 +30,10 @@ local coroutineTree = {}
 local stackFrame = {}
 local skipFrame = 0
 local baseL
+local continueSkipSource
+local continueSkipLine
+local stoppedSource
+local stoppedLine
 
 local CMD = {}
 
@@ -495,8 +499,11 @@ function CMD.stop(pkg)
 end
 
 function CMD.run()
+    if state == 'stopped' and stoppedSource and stoppedLine then
+        continueSkipSource = stoppedSource
+        continueSkipLine = stoppedLine
+    end
     state = 'running'
-    hookmgr.break_closeline()
     hookmgr.step_cancel()
 end
 
@@ -595,8 +602,20 @@ local function event_breakpoint(src, line)
         hookmgr.break_closeline()
         return
     end
-    local bp = breakpoint.hit_bp(src, source.line(src, line))
+    local currentline = source.line(src, line)
+    if continueSkipSource ~= nil then
+        if continueSkipSource == src and continueSkipLine == currentline then
+            continueSkipSource = nil
+            continueSkipLine = nil
+            return
+        end
+        continueSkipSource = nil
+        continueSkipLine = nil
+    end
+    local bp = breakpoint.hit_bp(src, currentline)
     if bp then
+        stoppedSource = src
+        stoppedLine = currentline
         state = 'stopped'
         runLoop {
             reason = 'breakpoint',
@@ -653,6 +672,8 @@ function event.step(line)
         hookmgr.step_cancel()
     end
     if state == 'stopped' then
+        stoppedSource = src
+        stoppedLine = source.line(src, line)
         runLoop {
             reason = stopReason
         }


### PR DESCRIPTION
## 问题描述

VSCode 更新后出现回归：在断点暂停期间移除该断点，再继续执行时，仍会再次命中这个已删除的断点。

## 根本原因

调试器从暂停态恢复执行（Continue）时，当前行级 hook 在一个调度周期内仍处于激活状态。如果断点在此时已被移除，该行的旧断点状态会在 Continue 后的第一次触发中被重复感知，导致误命中。

## 修复方案

在 `CMD.run()` 恢复执行时，记录当前停住的位置（source + line）。在后续断点判断（`event_breakpoint`）中，如果命中的正好是 Continue 前停住的那一行，则跳过本次命中并清空标记。

这是「单次跳过」策略，仅影响 Continue 后第一次遇到原停住行的情况，不会干扰同函数内其他行的断点检测。

## 影响

- 修复了 Continue 后误命中已移除断点的问题
- 同函数内多个断点仍可连续正常命中，无回归
