### PR TITLE
修复移除断点后 Continue 仍命中旧断点的问题

### DIFF
--- a/extension/script/backend/worker/breakpoint.lua
+++ b/extension/script/backend/worker/breakpoint.lua
@@ -274,6 +274,10 @@ function m.set_bp(clientsrc, breakpoints, content)
         else
             cantVerifyBreakpoints(breakpoints)
         end
+        -- When source is found, sync waitverify so that newly-loaded protos
+        -- use currentactive instead of stale waitverify entries.
+        waitverify[bpClientKey(clientsrc)] = nil
+        updateHook()
     else
         waitverify[bpClientKey(clientsrc)] = {
             breakpoints = breakpoints,

--- a/extension/script/backend/worker/breakpoint.lua
+++ b/extension/script/backend/worker/breakpoint.lua
@@ -274,8 +274,6 @@ function m.set_bp(clientsrc, breakpoints, content)
         else
             cantVerifyBreakpoints(breakpoints)
         end
-        -- When source is found, sync waitverify so that newly-loaded protos
-        -- use currentactive instead of stale waitverify entries.
         waitverify[bpClientKey(clientsrc)] = nil
         updateHook()
     else


### PR DESCRIPTION
﻿## 背景
在命中断点后，如果在暂停状态把该断点移除，再点击 Continue，调试器仍会继续命中这个已经删除的断点。

从 `client.log` 可见关键时序：
- 先收到 `setBreakpoints(..., breakpoints: [])`
- 紧接着 Continue 后出现 `breakpoint changed (id:1, verified:true)`
- 随后再次 `stopped (hitBreakpointIds:[1])`

这说明被删除的断点在运行过程中被重新激活了。

## 根因
worker 端在 `set_bp` 中如果已经能解析到 `srcarray`，会更新 `currentactive`，但不会同步清理 `waitverify[bpClientKey]`。

当后续有新 proto 加载时，`newproto` 会优先读取残留的 `waitverify`，从而把旧断点重新 verify 并重新加入 hook，导致已删除断点“复活”。

## 修复
在 `set_bp` 的 `srcarray` 分支完成处理后，补充：
- 清理 `waitverify[bpClientKey(clientsrc)]`
- 调用 `updateHook()` 同步 hook 状态

这样后续 `newproto` 将依据最新的 `currentactive`，不会再从过期 `waitverify` 复活已删除断点。

## 额外说明
本次提交按要求移除了新增代码注释，仅保留必要逻辑变更。
