### PR TITLE
fix: 修复记录点(logpoint)在调试控制台中显示位置不正确的问题

### DIFF
--- a/extension/script/backend/worker/breakpoint.lua
+++ b/extension/script/backend/worker/breakpoint.lua
@@ -311,7 +311,7 @@ function m.exec(bp)
             end
             return tostring(res)
         end)
-        rdebug.getinfo(1, "Sl", info)
+        rdebug.getinfo(0, "Sl", info)
         stdout(res, info)
         return false
     end


### PR DESCRIPTION
## 问题描述

当使用断点的「记录点」（logpoint）功能时，调试控制台右侧显示的源码位置不正确。

**实际行为**：显示的位置是调用「包含记录点的函数」的那一层调用者的位置，而非记录点本身所在的文件和行号。

**期望行为**：显示的位置应该是记录点所在的源文件和行号。

## 根本原因

在 \extension/script/backend/worker/breakpoint.lua\ 的 \m.exec\ 函数中，当记录点触发并需要打印日志时，原来的代码使用了：

\\\lua
rdebug.getinfo(1, 'Sl', info)
\\\

在 break hook 上下文中，\debug.getinfo\ 的层级含义如下：
- \level 0\：break hook 触发处，即**记录点所在函数的当前执行位置**
- \level 1\：该函数的调用者，即**调用包含记录点的函数的那一层**

由于使用了 \level 1\，\stdout\ 拿到的 \info\ 是调用者的位置，最终导致调试控制台右侧显示的是错误的位置。

## 修复方案

将 \level 1\ 改为 \level 0\，使其取到记录点自身触发时的位置：

\\\lua
rdebug.getinfo(0, 'Sl', info)
\\\

## 疑问

请问之前使用 \level 1\ 是否是有意为之的设计？例如是否存在某些特殊情况导致 \level 0\ 无法正确取到位置信息，因此才退一层取 \level 1\？如果是有意设计，烦请说明原因，我们可以一起讨论更合适的修复方案。