### PR TITLE
新增 syntaxCompatibility 配置项：显式指定使用调试目标解释器解析源码

### DIFF
--- a/compile/common/package_json.lua
+++ b/compile/common/package_json.lua
@@ -164,6 +164,11 @@ attributes.common = {
         markdownDescription = "%lua.debug.launch.luaVersion.description%",
         type = "string",
     },
+    syntaxCompatibility = {
+        default = false,
+        markdownDescription = "%lua.debug.launch.syntaxCompatibility.description%",
+        type = "boolean",
+    },
     outputCapture = {
         default = {
         },

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -4,7 +4,7 @@
     "lua.debug.launch.console.integratedTerminal.description": "VS Code integrated terminal.",
     "lua.debug.launch.console.externalTerminal.description": "External terminal that can be configured in user settings.",
     "lua.debug.launch.luaVersion.description": "Default lua version.",
-    "lua.debug.launch.syntaxCompatibility.description": "Use the target Lua VM to parse source syntax for breakpoint line information.",
+    "lua.debug.launch.syntaxCompatibility.description": "Use the target Lua VM to parse source syntax for breakpoint line information. Note: only takes effect for Lua 5.3+ targets and requires a compatible bytecode format.",
     "lua.debug.launch.luaArch.description": "Default lua arch.",
     "lua.debug.launch.sourceCoding.description": "Source encoding.",
     "lua.debug.launch.path.description": "Search path for Lua programs",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -4,6 +4,7 @@
     "lua.debug.launch.console.integratedTerminal.description": "VS Code integrated terminal.",
     "lua.debug.launch.console.externalTerminal.description": "External terminal that can be configured in user settings.",
     "lua.debug.launch.luaVersion.description": "Default lua version.",
+    "lua.debug.launch.syntaxCompatibility.description": "Use the target Lua VM to parse source syntax for breakpoint line information.",
     "lua.debug.launch.luaArch.description": "Default lua arch.",
     "lua.debug.launch.sourceCoding.description": "Source encoding.",
     "lua.debug.launch.path.description": "Search path for Lua programs",

--- a/extension/script/backend/worker/breakpoint.lua
+++ b/extension/script/backend/worker/breakpoint.lua
@@ -15,6 +15,11 @@ local protosById = {}       -- {["{ld}_{lld}_{srcId}"] = proto}
 local waitinstbp = {}       -- {[funcId] = {[pc] = bp}}
 local m = {}
 local enable = false
+local syntaxCompatibility = false
+
+ev.on('initializing', function(config)
+    syntaxCompatibility = config.syntaxCompatibility == true
+end)
 
 local function updateHook()
     local hasInstBp = next(instbreakpoints) ~= nil or next(waitinstbp) ~= nil
@@ -211,7 +216,7 @@ function m.find(src, currentline)
 end
 
 local function parserInlineLineinfo(src)
-    local old = parser(src.content)
+    local old = parser(src.content, syntaxCompatibility)
     if not old then
         return
     end
@@ -241,9 +246,9 @@ local function calcLineInfo(src, content)
         if src.content then
             src.lineinfo = parserInlineLineinfo(src)
         elseif content then
-            src.lineinfo = parser(content)
+            src.lineinfo = parser(content, syntaxCompatibility)
         elseif src.sourceReference then
-            src.lineinfo = parser(source.getCode(src.sourceReference))
+            src.lineinfo = parser(source.getCode(src.sourceReference), syntaxCompatibility)
         end
     end
     return src.lineinfo
@@ -531,6 +536,7 @@ ev.on('terminated', function()
     waitinstbp = {}
     info = {}
     enable = false
+    syntaxCompatibility = false
     hookmgr.break_open(false)
     if hookmgr.instbreak_open then
         hookmgr.instbreak_open(false)

--- a/extension/script/backend/worker/eval.lua
+++ b/extension/script/backend/worker/eval.lua
@@ -45,7 +45,7 @@ end
 generate("dump", function()
     local eval_dump = assert(rdebug.load(readfile 'backend.worker.eval.dump'))
     return function(content)
-        return rdebug.eval(eval_dump, content, 0)
+        return rdebug.eval(eval_dump, content)
     end
 end)
 

--- a/extension/script/backend/worker/eval.lua
+++ b/extension/script/backend/worker/eval.lua
@@ -46,11 +46,14 @@ generate("dump", function()
     if luaver.LUAVERSION <= 52 then
         local compat_dump = assert(load(readfile 'backend.worker.eval.dump'))
         return function(content)
-            local res, err = compat_dump(content)
-            if res then
+            local ok, res, err = pcall(compat_dump, content)
+            if ok and res ~= nil then
                 return true, res
             end
-            return false, err
+            if ok then
+                return false, 'can not dump function.'
+            end
+            return false, res
         end
     else
         local eval_dump = assert(rdebug.load(readfile 'backend.worker.eval.dump'))

--- a/extension/script/backend/worker/eval.lua
+++ b/extension/script/backend/worker/eval.lua
@@ -42,6 +42,24 @@ local function generate(name, init)
     end
 end
 
+generate("dump", function()
+    if luaver.LUAVERSION <= 52 then
+        local compat_dump = assert(load(readfile 'backend.worker.eval.dump'))
+        return function(content)
+            local res, err = compat_dump(content)
+            if res then
+                return true, res
+            end
+            return false, err
+        end
+    else
+        local eval_dump = assert(rdebug.load(readfile 'backend.worker.eval.dump'))
+        return function(content)
+            return rdebug.eval(eval_dump, content, 0)
+        end
+    end
+end)
+
 generate("ffi_reflect", function ()
     if not luaver.isjit then
         return

--- a/extension/script/backend/worker/eval.lua
+++ b/extension/script/backend/worker/eval.lua
@@ -43,23 +43,9 @@ local function generate(name, init)
 end
 
 generate("dump", function()
-    if luaver.LUAVERSION <= 52 then
-        local compat_dump = assert(load(readfile 'backend.worker.eval.dump'))
-        return function(content)
-            local ok, res, err = pcall(compat_dump, content)
-            if ok and res ~= nil then
-                return true, res
-            end
-            if ok then
-                return false, 'can not dump function.'
-            end
-            return false, res
-        end
-    else
-        local eval_dump = assert(rdebug.load(readfile 'backend.worker.eval.dump'))
-        return function(content)
-            return rdebug.eval(eval_dump, content, 0)
-        end
+    local eval_dump = assert(rdebug.load(readfile 'backend.worker.eval.dump'))
+    return function(content)
+        return rdebug.eval(eval_dump, content, 0)
     end
 end)
 

--- a/extension/script/backend/worker/eval/dump.lua
+++ b/extension/script/backend/worker/eval/dump.lua
@@ -1,0 +1,6 @@
+local content = ...
+local f = load(content, "=eval.dump")
+if not f then
+    return
+end
+return string.dump(f)

--- a/extension/script/backend/worker/eval/dump.lua
+++ b/extension/script/backend/worker/eval/dump.lua
@@ -1,6 +1,6 @@
 local content = ...
-local f = load(content, "=eval.dump")
+local f, err = load(content, "=eval.dump")
 if not f then
-    return
+    error(err, 0)
 end
 return string.dump(f)

--- a/extension/script/backend/worker/parser.lua
+++ b/extension/script/backend/worker/parser.lua
@@ -110,7 +110,12 @@ return function (content, syntaxCompatibility)
         log.error("ERROR:"..(err or "unknown error"))
         return
     end
-    local cl, v = undump(bin)
+    local ok, cl, v = pcall(undump, bin)
+    if not ok then
+        local log = require 'common.log'
+        log.error("ERROR:"..tostring(cl))
+        return
+    end
     version = v
     local si = { activelines = {}, definelines = {} }
     local lineinfo = {}

--- a/extension/script/backend/worker/parser.lua
+++ b/extension/script/backend/worker/parser.lua
@@ -96,25 +96,31 @@ end
 return function (content, syntaxCompatibility)
     local err
     local bin
+    local cl, v
     if syntaxCompatibility then
         bin, err = dumpTarget(content)
+        if not bin then
+            local log = require 'common.log'
+            log.error("ERROR:"..(err or "unknown error"))
+            return
+        end
+        local ok
+        ok, cl, v = pcall(undump, bin)
+        if not ok then
+            local log = require 'common.log'
+            log.error("ERROR:"..tostring(cl))
+            return
+        end
     else
         local f
         f, err = load(content)
-        if f then
-            bin = string.dump(f)
+        if not f then
+            local log = require 'common.log'
+            log.error("ERROR:"..(err or "unknown error"))
+            return
         end
-    end
-    if not bin then
-        local log = require 'common.log'
-        log.error("ERROR:"..(err or "unknown error"))
-        return
-    end
-    local ok, cl, v = pcall(undump, bin)
-    if not ok then
-        local log = require 'common.log'
-        log.error("ERROR:"..tostring(cl))
-        return
+        bin = string.dump(f)
+        cl, v = undump(bin)
     end
     version = v
     local si = { activelines = {}, definelines = {} }

--- a/extension/script/backend/worker/parser.lua
+++ b/extension/script/backend/worker/parser.lua
@@ -84,14 +84,32 @@ local function normalize(lineinfo, si)
     end
 end
 
-return function (content)
-    local f, err = load(content)
-    if not f then
+local function dumpTarget(content)
+    local eval = require 'backend.worker.eval'
+    local ok, bin = eval.dump(content)
+    if ok and type(bin) == "string" then
+        return bin
+    end
+    return nil, type(bin) == "string" and bin or "can not dump function."
+end
+
+return function (content, syntaxCompatibility)
+    local err
+    local bin
+    if syntaxCompatibility then
+        bin, err = dumpTarget(content)
+    else
+        local f
+        f, err = load(content)
+        if f then
+            bin = string.dump(f)
+        end
+    end
+    if not bin then
         local log = require 'common.log'
-        log.error("ERROR:"..err)
+        log.error("ERROR:"..(err or "unknown error"))
         return
     end
-    local bin = string.dump(f)
     local cl, v = undump(bin)
     version = v
     local si = { activelines = {}, definelines = {} }

--- a/extension/script/backend/worker/undump.lua
+++ b/extension/script/backend/worker/undump.lua
@@ -528,6 +528,7 @@ local undump55; do
     end
 
     function undump55(cl)
+        cached = {}
         CheckHeader()
         cl.nupvalues = LoadByte()
         cl.f = {}


### PR DESCRIPTION
之前解析文件时只使用默认解释器。如果调试目标使用了自定义语法，那么将会解析失败，导致断点无法生效。

本次改动：

- 新增 launch 配置项 `syntaxCompatibility`（默认关闭）。开启后使用调试目标的解释器执行 `load` + `string.dump`，为断点生成行号信息（恢复此前删除的 eval.dump 机制）。
- 修复 `undump55` 的字符串缓存未重置问题：多次解析时缓存跨调用残留，导致内存累积与字符串索引错位。

注意：该配置只能解决语法解析问题，无法解决字节码格式不兼容的情况。